### PR TITLE
adding keras_preprocessing dependency for DGA detection

### DIFF
--- a/requirements_files/specific_golden_cpu.txt
+++ b/requirements_files/specific_golden_cpu.txt
@@ -34,5 +34,7 @@ spacytextblob==0.1.7
 
 pymilvus
 
+keras_preprocessing
+
  --extra-index-url https://download.pytorch.org/whl/cpu
  torch

--- a/requirements_files/specific_minimal_cpu.txt
+++ b/requirements_files/specific_minimal_cpu.txt
@@ -9,3 +9,5 @@ mlflow==2.7.0
 scipy
 scikit-learn
 networkx
+
+keras_preprocessing


### PR DESCRIPTION
keras_preprocessing is needed for the prebuilt DGA detection