### PR TITLE
Handle images created on windows machines

### DIFF
--- a/dockerfiles/Dockerfile.debian
+++ b/dockerfiles/Dockerfile.debian
@@ -51,6 +51,13 @@ COPY ./bootstrap_scripts/bootstrap_fast.sh /dltk/
 COPY app /dltk/app
 COPY notebooks /dltk/notebooks
 
+# Install dos2unix, then convert windows-like line endings to linux-like
+# The bootstrap script won't run otherwise if the image was build on a windows machine
+# Finally, remove dos2unix again
+RUN apt-get update && apt-get install -y dos2unix
+RUN find /dltk/ -name 'bootstrap_*.sh' -type f -exec dos2unix {} \;
+RUN apt-get --purge remove -y dos2unix && rm -rf /var/lib/apt/lists/*
+
 # Install local DSDL supporting functions
 RUN mkdir /dltk/packages
 COPY package-dsdlsupport/dist/dsdlsupport-1.0.0.tar.gz /dltk/packages/dsdlsupport-1.0.0.tar.gz

--- a/dockerfiles/Dockerfile.debian.escu
+++ b/dockerfiles/Dockerfile.debian.escu
@@ -50,6 +50,13 @@ COPY ./bootstrap_scripts/bootstrap_fast.sh /dltk/
 COPY app /dltk/app
 COPY notebooks /dltk/notebooks
 
+# Install dos2unix, then convert windows-like line endings to linux-like
+# The bootstrap script won't run otherwise if the image was build on a windows machine
+# Finally, remove dos2unix again
+RUN apt-get update && apt-get install -y dos2unix
+RUN find /dltk/ -name 'bootstrap_*.sh' -type f -exec dos2unix {} \;
+RUN apt-get --purge remove -y dos2unix && rm -rf /var/lib/apt/lists/*
+
 # Install local DSDL supporting functions
 RUN mkdir /dltk/packages
 COPY package-dsdlsupport/dist/dsdlsupport-1.0.0.tar.gz /dltk/packages/dsdlsupport-1.0.0.tar.gz

--- a/dockerfiles/Dockerfile.debian.rapids
+++ b/dockerfiles/Dockerfile.debian.rapids
@@ -48,6 +48,13 @@ COPY bootstrap_scripts/bootstrap_rapids.sh /dltk/
 COPY app /dltk/app
 COPY notebooks /dltk/notebooks
 
+# Install dos2unix, then convert windows-like line endings to linux-like
+# The bootstrap script won't run otherwise if the image was build on a windows machine
+# Finally, remove dos2unix again
+RUN apt-get update && apt-get install -y dos2unix
+RUN find /dltk/ -name 'bootstrap_*.sh' -type f -exec dos2unix {} \;
+RUN apt-get --purge remove -y dos2unix && rm -rf /var/lib/apt/lists/*
+
 # Install local DSDL supporting functions
 RUN mkdir /dltk/packages
 COPY package-dsdlsupport/dist/dsdlsupport-1.0.0.tar.gz /dltk/packages/dsdlsupport-1.0.0.tar.gz

--- a/dockerfiles/Dockerfile.debian.spark
+++ b/dockerfiles/Dockerfile.debian.spark
@@ -53,6 +53,13 @@ COPY ./bootstrap_scripts/bootstrap_fast.sh /dltk/
 COPY app /dltk/app
 COPY notebooks /dltk/notebooks
 
+# Install dos2unix, then convert windows-like line endings to linux-like
+# The bootstrap script won't run otherwise if the image was build on a windows machine
+# Finally, remove dos2unix again
+RUN apt-get update && apt-get install -y dos2unix
+RUN find /dltk/ -name 'bootstrap_*.sh' -type f -exec dos2unix {} \;
+RUN apt-get --purge remove -y dos2unix && rm -rf /var/lib/apt/lists/*
+
 # Install local DSDL supporting functions
 RUN mkdir /dltk/packages
 COPY package-dsdlsupport/dist/dsdlsupport-1.0.0.tar.gz /dltk/packages/dsdlsupport-1.0.0.tar.gz

--- a/dockerfiles/Dockerfile.debian.transformers
+++ b/dockerfiles/Dockerfile.debian.transformers
@@ -45,6 +45,13 @@ COPY ./bootstrap_scripts/bootstrap_transformers.sh /dltk/
 COPY app /dltk/app
 COPY notebooks /dltk/notebooks
 
+# Install dos2unix, then convert windows-like line endings to linux-like
+# The bootstrap script won't run otherwise if the image was build on a windows machine
+# Finally, remove dos2unix again
+RUN apt-get update && apt-get install -y dos2unix
+RUN find /dltk/ -name 'bootstrap_*.sh' -type f -exec dos2unix {} \;
+RUN apt-get --purge remove -y dos2unix && rm -rf /var/lib/apt/lists/*
+
 # copy and expand transformer content
 ADD basemodels/class_en.tar.gz /dltk/app/model/data/classification/en
 ADD basemodels/class_jp.tar.gz /dltk/app/model/data/classification/jp

--- a/dockerfiles/Dockerfile.redhat
+++ b/dockerfiles/Dockerfile.redhat
@@ -50,6 +50,13 @@ COPY ./bootstrap_scripts/bootstrap_fast.sh /dltk/
 COPY app /dltk/app
 COPY notebooks /dltk/notebooks
 
+# Install dos2unix, then convert windows-like line endings to linux-like
+# The bootstrap script won't run otherwise if the image was build on a windows machine
+# Finally, remove dos2unix again
+RUN apt-get update && apt-get install -y dos2unix
+RUN find /dltk/ -name 'bootstrap_*.sh' -type f -exec dos2unix {} \;
+RUN apt-get --purge remove -y dos2unix && rm -rf /var/lib/apt/lists/*
+
 # Install local DSDL supporting functions
 RUN mkdir /dltk/packages
 COPY package-dsdlsupport/dist/dsdlsupport-1.0.0.tar.gz /dltk/packages/dsdlsupport-1.0.0.tar.gz

--- a/dockerfiles/Dockerfile.redhat
+++ b/dockerfiles/Dockerfile.redhat
@@ -53,9 +53,9 @@ COPY notebooks /dltk/notebooks
 # Install dos2unix, then convert windows-like line endings to linux-like
 # The bootstrap script won't run otherwise if the image was build on a windows machine
 # Finally, remove dos2unix again
-RUN apt-get update && apt-get install -y dos2unix
+RUN yum install -y dos2unix
 RUN find /dltk/ -name 'bootstrap_*.sh' -type f -exec dos2unix {} \;
-RUN apt-get --purge remove -y dos2unix && rm -rf /var/lib/apt/lists/*
+RUN yum remove -y dos2unix && yum clean all
 
 # Install local DSDL supporting functions
 RUN mkdir /dltk/packages


### PR DESCRIPTION
When building new images with build.sh on a windows machine, line endings of files within the new image are windows-like (\r\n) instead of linux-like (\n). Following an example of the /dltk/bootstrap_fast.sh file, after its creation on a windows machine:

`cat -v /dltk/bootstrap_fast.sh`

_#!/bin/sh^M
export LC_ALL=C.UTF-8^M
export LANG=C.UTF-8^M
..._

Containers then can not be spawned from this image on a linux machine (e.g. a Splunk instance running dsdl):

`/dltk/bootstrap_fast.sh`
_bash: /dltk/bootstrap_fast.sh: cannot execute: required file not found_

By merging the proposed changes, the line endings of `bootstrap_*.sh` within the /dltk/ directory are changed to be linux-like.

I suspect that this issue, creating an image on a windows machine and then spawning containers on a linux server, might arise frequently with users like me (data scientist/splunk architect who works on a company workstation using windows and maintaining Splunk instances on linux servers).

Regards from Switzerland,
Schiggy